### PR TITLE
Patch 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
   ],
   "author": "",
   "homepage": "",
-  "dependencies": {
+  "devDependencies": {
+    "babel-core": "^4.7.x",
+    "babel-loader": "^4.1.x",
     "webpack": ">=1.3.0-beta8",
-    "jsx-loader": ">=0.10.0",
+  },
+  "dependencies": {
     "react": ">=0.10.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,8 +35,8 @@ module.exports = {
     module: {
         /* Loaders are how webpack compiles and builds the JSX extensions */
         loaders: [
-            /* Any file with a .jsx extension will go through the jsx-loader */
-            { test: /\.jsx$/, loader: "jsx-loader?harmony" }
+            /* Any file with a .js extension will go through the babel-loader */
+            {test: /\.js$/, loader: 'babel-loader', exclude: /node_modules/}
         ]
     }
 };


### PR DESCRIPTION
Switch to babel loader since it has better ES6 support. Move things into dev dependencies. Don't compile node_modules stuff.
